### PR TITLE
fix: unspecified aggregate shown as undefined

### DIFF
--- a/src/DataSource.ts
+++ b/src/DataSource.ts
@@ -118,7 +118,7 @@ export class DataSource extends DataSourceApi<SignalKQuery, SignalKDataSourceOpt
       });
       dataframe.addField({ name: 'time', type: FieldType.time });
       enabledTargets.forEach((target) => {
-        dataframe.addField({ name: `${target.path}:${target.aggregate}`, type: FieldType.number });
+        dataframe.addField({ name: `${target.path}:${target.aggregate || 'average'}`, type: FieldType.number });
       });
 
       const onDataInserted = () => {


### PR DESCRIPTION
If the aggregate method was unspecified it defaults to average, but the UI was showing it as undefined.