### PR TITLE
fix: data outside timeframe error

### DIFF
--- a/src/DataSource.ts
+++ b/src/DataSource.ts
@@ -94,9 +94,8 @@ export class DataSource extends DataSourceApi<SignalKQuery, SignalKDataSourceOpt
   }
 
   getWebsocketUrl() {
-    return `ws${window.location.protocol === 'https' ? 's' : ''}://${window.location.host}${
-      this.url
-    }/${this.getProxyName()}/signalk/v1/stream`;
+    return `ws${window.location.protocol === 'https' ? 's' : ''}://${window.location.host}${this.url
+      }/${this.getProxyName()}/signalk/v1/stream`;
   }
 
   query(options: DataQueryRequest<SignalKQuery>): Observable<DataQueryResponse> {


### PR DESCRIPTION
    Fix 'Data outside timeframe' error that was caused by
    not converting the timestamp to a Date.
    
    Also refactor the result rxjs: use Subject instead
    of an Observable. Using Observable worked if there
    ever were just one subscriber, but since there were
    more the data fetching was running more than once and
    there seemed to be multiple idle timers.
