### PR TITLE
fix: set metrics: true in plugin.json

### DIFF
--- a/src/plugin.json
+++ b/src/plugin.json
@@ -2,7 +2,7 @@
   "type": "datasource",
   "name": "Signal K",
   "id": "tkurki-signalk-datasource",
-  "metrics": false,
+  "metrics": true,
   "streaming": true,
   "routes": [
     {


### PR DESCRIPTION
I have no idea how I've missed this earlier OR
how the datasource has worked previously, because
I find it hard to believe it has never worked.

Anyway, this fixes #6 and #4.