### PR TITLE
fix: iterate result data more defensively

### DIFF
--- a/src/DataSource.ts
+++ b/src/DataSource.ts
@@ -179,7 +179,8 @@ export class DataSource extends DataSourceApi<SignalKQuery, SignalKDataSourceOpt
         const seriesConversions = enabledTargets.map(getConversion);
         if (result) {
           result.data.forEach((row: number[]) => {
-            const rowToInsert = row.slice(1).map((value, i) => seriesConversions[i](value));
+//            const rowToInsert = row.slice(1).map((value, i) => seriesConversions[i](value));
+            const rowToInsert = seriesConversions.map((conversion, i) => conversion(row[i + 1]));
             const ts = new Date(row[0]);
             (rowToInsert as any[]).unshift(ts);
             dataframe.appendRow(rowToInsert);


### PR DESCRIPTION
signalk-parquet was returning more series than
requested, which would fail in processing the
result.

This changes result processing so that only
the series that were requested are handled and
any extra fields on the row are ignored.