### PR TITLE
Fix WebSocket failures when Grafana is served over HTTPS

### DIFF
--- a/src/DataSource.ts
+++ b/src/DataSource.ts
@@ -71,22 +71,26 @@ export class DataSource extends DataSourceApi<SignalKQuery, SignalKDataSourceOpt
   }
 
   ensureWsIsOpen() {
-    if (this.ws) {
-      return;
-    }
-    this.ws = new ReconnectingWebsocket(this.getWebsocketUrl());
-    this.ws.onmessage = (event) => {
-      const msg = JSON.parse(event.data);
-      if (msg.updates) {
-        msg.updates.forEach((update: any) => {
-          if (update.values) {
-            update.values.forEach((pathValue: any) => {
-              this.pathValueHandlers.forEach((handler) => handler(pathValue, update));
-            });
-          }
-        });
+    try {
+      if (this.ws) {
+        return;
       }
-    };
+      this.ws = new ReconnectingWebsocket(this.getWebsocketUrl());
+      this.ws.onmessage = (event) => {
+        const msg = JSON.parse(event.data);
+        if (msg.updates) {
+          msg.updates.forEach((update: any) => {
+            if (update.values) {
+              update.values.forEach((pathValue: any) => {
+                this.pathValueHandlers.forEach((handler) => handler(pathValue, update));
+              });
+            }
+          });
+        }
+      };
+    } catch (e: any) {
+      console.warn('WebSocket connection failed:', e.message);
+    }
   }
 
   getProxyName() {
@@ -94,7 +98,7 @@ export class DataSource extends DataSourceApi<SignalKQuery, SignalKDataSourceOpt
   }
 
   getWebsocketUrl() {
-    return `ws${window.location.protocol === 'https' ? 's' : ''}://${window.location.host}${this.url
+    return `ws${window.location.protocol === 'https:' ? 's' : ''}://${window.location.host}${this.url
       }/${this.getProxyName()}/signalk/v1/stream`;
   }
 


### PR DESCRIPTION
  
  ## Summary

Fixes two bugs that cause "No data" in all panels when Grafana is accessed over HTTPS (e.g. behind a reverse proxy like Caddy or nginx).

We discovered this while integrating the SignalK datasource into the [SignalK Universal Installer](https://github.com/SignalK/signalk-universal-installer), where Grafana runs behind Caddy as a reverse proxy at `/grafana/` over HTTPS. Every panel showed "No data" despite the history API being fully reachable.

## Root Cause

**1. Protocol comparison bug in `getWebsocketUrl()`** (line 97)

```typescript
// Before (always false — 'https' !== 'https:')
ws${window.location.protocol === 'https' ? 's' : ''}://...

// After
ws${window.location.protocol === 'https:' ? 's' : ''}://...
```

`window.location.protocol` returns `'https:'` (with colon), so the comparison always failed. The plugin always constructed `ws://` URLs, even on HTTPS pages. Browsers block `ws://` from HTTPS pages (mixed content), throwing a `SecurityError`.

**2. No error handling in `ensureWsIsOpen()`** (line 73)

The `SecurityError` from the WebSocket constructor propagated up through `query()`, preventing `doQuery()` (the HTTP history fallback) from ever running. This meant panels showed "No data" even though the history API worked fine — the error crashed the entire query pipeline before it could reach the HTTP path.

## Fix

- Add the missing colon to the protocol check so `wss://` is used on HTTPS pages
- Wrap `ensureWsIsOpen()` in try/catch so WebSocket failures degrade gracefully to history-only mode instead of crashing the query

## Test Plan

- Verified with Grafana behind Caddy HTTPS reverse proxy — panels now show historical data
- WebSocket streaming also works correctly with the `wss://` fix
- When WebSocket is unavailable (e.g. proxy doesn't support it), history queries still work via HTTP fallback